### PR TITLE
branch:HPCC-27615-add-rm-0000-cidr

### DIFF
--- a/scripts/remove0000
+++ b/scripts/remove0000
@@ -1,0 +1,5 @@
+#!/bin/sh
+storage_account=$1
+resource_group=$2
+az storage account network-rule remove --account-name $storage_account --ip-address "0.0.0.0/0" --resource-group $resource_group
+

--- a/storage.tf
+++ b/storage.tf
@@ -39,7 +39,7 @@ resource "azurerm_storage_account" "azurefiles" {
 
   network_rules {
     default_action             = "Deny"
-    ip_rules                   = values(merge(each.value.authorized_ip_ranges, { host_ip = data.http.host_ip.response_body }))
+    ip_rules                   = values(merge(each.value.authorized_ip_ranges, { anyone = "0.0.0.0/0" }, { host_ip = data.http.host_ip.response_body }))
     virtual_network_subnet_ids = var.subnet_ids //values(each.value.subnet_ids)
     bypass                     = ["AzureServices"]
   }
@@ -74,7 +74,7 @@ resource "azurerm_storage_account" "blobnfs" {
 
   network_rules {
     default_action             = "Deny"
-    ip_rules                   = values(merge(each.value.authorized_ip_ranges, { host_ip = data.http.host_ip.response_body }))
+    ip_rules                   = values(merge(each.value.authorized_ip_ranges, { anyone = "0.0.0.0/0" }, { host_ip = data.http.host_ip.response_body }))
     virtual_network_subnet_ids = var.subnet_ids //values(each.value.subnet_ids)
     bypass                     = ["AzureServices"]
   }


### PR DESCRIPTION
To get storage to deploy successfully, I added 0.0.0.0/0 to ip_rules for both azurefiles and blob. Then, after azurefiles and containers were created, I deleted 0.0.0.0/0 from the firewall of each storage account.